### PR TITLE
Add unit testing.

### DIFF
--- a/src/Services/RestrictMiddleware.php
+++ b/src/Services/RestrictMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\restrict\Services;
 
+use Drupal\restrict\RestrictManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -42,7 +43,7 @@ class RestrictMiddleware implements HttpKernelInterface {
    * @param \Drupal\Core\Site\Settings $settings
    *   The site settings.
    */
-  public function __construct(HttpKernelInterface $http_kernel, RestrictManager $manager) {
+  public function __construct(HttpKernelInterface $http_kernel, RestrictManagerInterface $manager) {
     $this->httpKernel = $http_kernel;
     $this->restrictManager = $manager;
   }

--- a/tests/src/Unit/RestrictManagerTest.php
+++ b/tests/src/Unit/RestrictManagerTest.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\Tests\restrict\Unit\RestrictManagerTest
+ */
+
+namespace Drupal\Tests\restrict\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\restrict\RestrictManager;
+
+/**
+ * Unit tests for IP checking.
+ *
+ * @coversDefaultClass2 \Drupal\restrict\RestrictManager;
+ * @group restrict
+ */
+class RestrictManagerTest extends UnitTestCase {
+
+  /**
+   * Generate a Request Mock object.
+   *
+   * @return Symfony\Component\HttpFoundation\Request
+   */
+  public function getRequestMock() {
+    $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $params = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+      ->disableOriginalConstructor()
+      ->setMethods(['getClientIp', 'getRequestUri'])
+      ->getMock();
+
+    $server = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMock();
+
+    $server->expects($this->any())
+      ->method('get')
+      ->with('REMOTE_ADDR')
+      ->willReturn('127.0.0.1');
+
+    $headers = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMock();
+
+    $headers->expects($this->any())
+      ->method('get')
+      ->willReturn('user');
+
+    $request->server = $server;
+    $request->request = $params;
+    $request->headers = $headers;
+
+    return $request;
+  }
+
+  /**
+   * Return a mock manager.
+   *
+   * @return array
+   *   A mocked RestrictManager
+   */
+  public function getRestrictManagerMock() {
+    $manager = $this->getMockBuilder('Drupal\restrict\RestrictManager')
+      ->disableOriginalConstructor();
+    return $manager;
+  }
+
+  /**
+   * Set up a rule that catches.
+   *
+   * @return MockObject
+   */
+  public function getPassRuleMock() {
+    $rule = $this->getMockBuilder('Rule')
+      ->setMethods(['set', 'assert'])
+      ->getMock();
+
+    $rule->expects($this->any())->method('assert')->willReturn(TRUE);
+    return $rule;
+  }
+
+  /**
+   * Set up a rule that does not catch.
+   *
+   * @return mixed
+   */
+  public function getFailRuleMock() {
+    $rule = $this->getMockBuilder('Rule')
+      ->setMethods(['set', 'assert'])
+      ->getMock();
+
+    $rule->expects($this->any())->method('assert')->willReturn(FALSE);
+    return $rule;
+  }
+
+  /**
+   * Ensure IP is specified with the request.
+   */
+  public function testNoRequestIp() {
+    $request = $this->getRequestMock();
+    $request->expects($this->once())
+      ->method('getClientIp')
+      ->willReturn(NULL);
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods(['getResponseCode', 'getRequest'])
+      ->getMock();
+
+    $manager->expects($this->once())
+      ->method('getResponseCode')
+      ->willReturn(RestrictManager::RESTRICT_FORBIDDEN);
+
+    // Add the request context.
+    $manager->expects($this->once())
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $this->assertEquals(RestrictManager::RESTRICT_FORBIDDEN, $manager->isRestricted());
+  }
+
+  /**
+   * Expect false if request IP is in whitelist.
+   */
+  public function testWhitelist() {
+    // Setup the request mock.
+    $request = $this->getRequestMock();
+    $request->expects($this->once())
+      ->method('getClientIp')
+      ->willReturn('10.0.0.1');
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods([
+        'getWhitelist',
+        'setRequestTrustedProxies',
+        'getRequest',
+        'getTrustedProxies',
+        'getRules'
+      ])
+      ->getMock();
+
+    $manager->expects($this->any())
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->exactly(2))
+      ->method('getWhitelist')
+      ->willReturn(['10.0.0.1']);
+
+    $manager->expects($this->any())
+      ->method('getRules')
+      ->willReturn($this->getPassRuleMock());
+
+    $this->assertFalse($manager->isRestricted());
+  }
+
+  /**
+   * Ensure that if the request is restricted we receive a forbidden.
+   */
+  public function testBlacklist() {
+    // Setup the request mock.
+    $request = $this->getRequestMock();
+    $request->expects($this->once())
+      ->method('getClientIp')
+      ->willReturn('10.0.0.1');
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods([
+        'getWhitelist',
+        'setRequestTrustedProxies',
+        'getRequest',
+        'getTrustedProxies',
+        'getRules',
+        'getBlacklist',
+        'getResponseCode',
+      ])
+      ->getMock();
+
+    $manager->expects($this->once())
+      ->method('getResponseCode')
+      ->willReturn(RestrictManager::RESTRICT_FORBIDDEN);
+
+    $manager->expects($this->any())
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->once())
+      ->method('getWhitelist')
+      ->willReturn([]);
+
+    $manager->expects($this->any())
+      ->method('getRules')
+      ->willReturn($this->getPassRuleMock());
+
+    $manager->expects($this->exactly(2))
+      ->method('getBlacklist')
+      ->willReturn(['10.0.0.1']);
+
+    $this->assertEquals(RestrictManager::RESTRICT_FORBIDDEN, $manager->isRestricted());
+  }
+
+  /**
+   * Test restricted paths.
+   */
+  public function testPaths() {
+    // Setup the request mock.
+    $request = $this->getRequestMock();
+    $request->expects($this->once())
+      ->method('getClientIp')
+      ->willReturn('10.0.0.1');
+
+    $request->expects($this->once())
+      ->method('getRequestUri')
+      ->willReturn('/mypath');
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods([
+        'getWhitelist',
+        'setRequestTrustedProxies',
+        'getRequest',
+        'getTrustedProxies',
+        'getRules',
+        'getBlacklist',
+        'getResponseCode',
+        'getRestrictedPaths',
+      ])
+      ->getMock();
+
+    $manager->expects($this->once())
+      ->method('getResponseCode')
+      ->willReturn(RestrictManager::RESTRICT_FORBIDDEN);
+
+    $manager->expects($this->any())
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->once())
+      ->method('getWhitelist')
+      ->willReturn([]);
+
+    $manager->expects($this->any())
+      ->method('getRules')
+      ->willReturn($this->getPassRuleMock());
+
+    $manager->expects($this->once())
+      ->method('getBlacklist')
+      ->willReturn([]);
+
+    $manager->expects($this->exactly(2))
+      ->method('getRestrictedPaths')
+      ->willReturn(['/mypath']);
+
+    $this->assertEquals(RestrictManager::RESTRICT_FORBIDDEN, $manager->isRestricted());
+  }
+
+  /**
+   * Ensure requests aren't restricted if not in path or blacklist.
+   */
+  public function testNotInBlacklistOrRestrictedPaths() {
+    // Setup the request mock.
+    $request = $this->getRequestMock();
+    $request->expects($this->once())
+      ->method('getClientIp')
+      ->willReturn('10.0.0.1');
+
+    $request->expects($this->once())
+      ->method('getRequestUri')
+      ->willReturn('/mypath');
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods([
+        'getWhitelist',
+        'setRequestTrustedProxies',
+        'getRequest',
+        'getTrustedProxies',
+        'getRules',
+        'getBlacklist',
+        'getResponseCode',
+        'getRestrictedPaths',
+      ])
+      ->getMock();
+
+    $manager->expects($this->any())
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->exactly(2))
+      ->method('getWhitelist')
+      ->willReturn(['10.0.0.1']);
+
+    $manager->expects($this->exactly(2))
+      ->method('getBlacklist')
+      ->willReturn(['10.0.0.1']);
+
+    $manager->expects($this->exactly(2))
+      ->method('getRestrictedPaths')
+      ->willReturn(['/mypath']);
+
+    $manager->expects($this->any())
+      ->method('getRules')
+      ->willReturn($this->getFailRuleMock());
+
+    $manager->expects($this->never())->method('getResponseCode');
+
+    $this->assertFalse($manager->isRestricted());
+  }
+
+  /**
+   * Ensure requests aren't restricted if not in path or blacklist.
+   */
+  public function testUnrestricted() {
+    // Setup the request mock.
+    $request = $this->getRequestMock();
+    $request->expects($this->once())
+      ->method('getClientIp')
+      ->willReturn('10.0.0.1');
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods([
+        'getWhitelist',
+        'setRequestTrustedProxies',
+        'getRequest',
+        'getTrustedProxies',
+        'getRules',
+        'getBlacklist',
+        'getResponseCode',
+        'getRestrictedPaths',
+      ])
+      ->getMock();
+
+    $manager->expects($this->any())
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->once())
+      ->method('getWhitelist')
+      ->willReturn([]);
+
+    $manager->expects($this->once())
+      ->method('getBlacklist')
+      ->willReturn([]);
+
+    $manager->expects($this->once())
+      ->method('getRestrictedPaths')
+      ->willReturn([]);
+
+    $manager->expects($this->once())->method('getRules')->willReturn($this->getFailRuleMock());
+    $manager->expects($this->never())->method('getResponseCode');
+
+    $this->assertFalse($manager->isRestricted());
+  }
+
+  /**
+   * Ensure if correct credentials are given the request is authorised.
+   */
+  public function testBsaicAuthWithDetails() {
+    $request = $this->getRequestMock();
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods(['getBasicAuthCredentials', 'getRequest'])
+      ->getMock();
+
+    $manager->expects($this->exactly(2))
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->once())
+      ->method('getBasicAuthCredentials')
+      ->willReturn(['user' => 'user']);
+
+    $this->assertTrue($manager->isAuthorised());
+  }
+
+  /**
+   * Ensure that requests are restricted if auth fails.
+   */
+  public function testUnauthorisedWithDetails() {
+    $request = $this->getRequestMock();
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods(['getBasicAuthCredentials', 'getRequest'])
+      ->getMock();
+
+    $manager->expects($this->exactly(2))
+      ->method('getRequest')
+      ->willReturn($request);
+
+    $manager->expects($this->once())
+      ->method('getBasicAuthCredentials')
+      ->willReturn(['user' => 'password']);
+
+    $this->assertFalse($manager->isAuthorised());
+  }
+
+  /**
+   * Ensure that requests aren't restricted if no auth is defined.
+   */
+  public function testUndefinedAuth() {
+    $request = $this->getRequestMock();
+
+    $manager = $this->getRestrictManagerMock()
+      ->setMethods(['getBasicAuthCredentials', 'getRequest'])
+      ->getMock();
+
+    $manager->expects($this->never())->method('getRequest');
+
+    $manager->expects($this->once())
+      ->method('getBasicAuthCredentials')
+      ->willReturn([]);
+
+    $this->assertTrue($manager->isAuthorised());
+  }
+}

--- a/tests/src/Unit/RestrictMiddlewareTest.php
+++ b/tests/src/Unit/RestrictMiddlewareTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\Tests\restrict\Unit\RestrictMiddlewareTest
+ */
+
+namespace Drupal\Tests\restrict\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\restrict\RestrictManager;
+use Drupal\restrict\Services\RestrictMiddleware;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Drupal\Core\Site\Settings;
+
+class RestrictMiddlewareTest extends UnitTestCase {
+
+  protected $kernel;
+
+  protected $restrictManager;
+
+  protected $restrictMiddleware;
+
+  protected $settings;
+
+  public function setup() {
+    parent::setup();
+
+    $this->kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+    $this->restrictManager = $this->getMock('Drupal\restrict\RestrictManagerInterface');
+    $this->restrictMiddleware = $this->getMockBuilder('Drupal\restrict\Services\RestrictMiddleware')
+      ->setConstructorArgs([$this->kernel, $this->restrictManager])
+      ->setMethods(['isCli'])
+      ->getMock();
+  }
+
+  /**
+   * Test a CLI request.
+   */
+  public function testIsCli() {
+    $this->restrictMiddleware
+      ->expects($this->once())
+      ->method('isCli')
+      ->willReturn(TRUE);
+
+    $request = Request::create('/test-path');
+
+    $this->kernel->expects($this->once())
+      ->method('handle')
+      ->with($request, HttpKernelInterface::MASTER_REQUEST, TRUE);
+
+    $this->restrictMiddleware->handle($request);
+  }
+
+  /**
+   * Test unauthorised requests.
+   */
+  public function testUnauthorised() {
+    $this->restrictManager->expects($this->once())->method('setRequest');
+    $this->restrictManager->expects($this->once())
+      ->method('isAuthorised')
+      ->willReturn(FALSE);
+
+    $request = Request::create('/test-path');
+    $response = $this->restrictMiddleware->handle($request);
+
+    $this->kernel->expects($this->never())->method('handle');
+    $this->assertEquals(401, $response->getStatusCode());
+  }
+
+  /**
+   * Test forbidden requests.
+   */
+  public function testIsRestrictedForbidden() {
+    $this->restrictManager->expects($this->once())->method('setRequest');
+    $this->restrictManager->expects($this->once())
+      ->method('isAuthorised')
+      ->willReturn(TRUE);
+
+    $this->restrictManager->expects($this->once())
+      ->method('isRestricted')
+      ->willReturn(RestrictManager::RESTRICT_FORBIDDEN);
+
+    $request = Request::create('/test-path');
+    $response = $this->restrictMiddleware->handle($request);
+
+    $this->kernel->expects($this->never())->method('handle');
+    $this->assertEquals(403, $response->getStatusCode());
+  }
+
+  /**
+   * Test not found requests.
+   */
+  public function testIsRestrictedNotFound() {
+    $this->restrictManager->expects($this->once())->method('setRequest');
+    $this->restrictManager->expects($this->once())
+      ->method('isAuthorised')
+      ->willReturn(TRUE);
+
+    $this->restrictManager->expects($this->once())
+      ->method('isRestricted')
+      ->willReturn(RestrictManager::RESTRICT_NOT_FOUND);
+
+    $request = Request::create('/test-path');
+    $response = $this->restrictMiddleware->handle($request);
+
+    $this->kernel->expects($this->never())->method('handle');
+    $this->assertEquals(404, $response->getStatusCode());
+  }
+
+  public function testDefaultRouteHandling() {
+    $request = Request::create('/test-path');
+
+    $this->restrictMiddleware
+      ->expects($this->once())
+      ->method('isCli')
+      ->willReturn(FALSE);
+
+    $this->restrictManager->expects($this->once())->method('setRequest');
+
+    $this->restrictManager->expects($this->once())
+      ->method('isAuthorised')
+      ->willReturn(TRUE);
+
+    $this->restrictManager->expects($this->once())
+      ->method('isRestricted')
+      ->willReturn(FALSE);
+
+    $this->kernel->expects($this->once())
+      ->method('handle')
+      ->with($request);
+
+    $this->restrictMiddleware->handle($request);
+  }
+}


### PR DESCRIPTION
- Adds additional unit tests around the middleware and middleware manager classes.
- Adjusts some of the API around the RestrictManager so that creating test doubles becomes easier
- Updates type hinting to expect the interface rather than the class as is best practice
