### PR TITLE
Allow combining of auth + path retrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,21 @@ An array of basic auth username => password combinations.
 $settings['restrict_basic_auth_credentials'] = [
   'Editor' => 'P455w0rd',
   'user' => 'password',
+  ]
 ];
 ```
 
 #### `$settings['restrict_restricted_paths'] Array`
 
-Paths which may not be accessed unless the user is on the IP whitelist. Paths should start with a leading '/'.
+Paths which may not be accessed unless the user is on the IP whitelist. Paths should start with a leading '/'. Path restrictions can have options specified by an associative array.
 
 ``` php
 $settings['restrict_restricted_paths'] = [
   '/path',
   '/path/to/restricted/resource',
+  '/path' => [
+    'auth' => ['username' => 'password'],
+   ],
 ];
 ```
 

--- a/src/Rules/BasicAuthRule.php
+++ b/src/Rules/BasicAuthRule.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\restrict\Rules\BasicAuthRule
+ */
+
+namespace Drupal\restrict\Rules;
+
+
+class BasicAuthRule extends RulesInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function assert() {
+    $credentials = $this->get('credentials');
+
+    if (empty($credentials)) {
+      // No credentials to check.
+      return TRUE;
+    }
+
+    // Get auth from request headers.
+    $username = $this->get('request')->headers->get('PHP_AUTH_USER');
+    $password = $this->get('request')->headers->get('PHP_AUTH_PW');
+
+    if (isset($username) && isset($password)) {
+      if (isset($credentials[$username]) && $credentials[$username] == $password) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+}

--- a/src/Rules/PathRule.php
+++ b/src/Rules/PathRule.php
@@ -11,18 +11,58 @@ use Drupal\restrict\Rules\RulesInterface;
 
 class PathRule extends RulesInterface {
 
+  public function getRule($rule, $with = []) {
+    // @TODO: Register rules as services so we don't manage these hashes.
+    $rules = ['auth' => new BasicAuthRule()];
+
+    if (empty($rules[$rule])) {
+      throw new \Exception('Invalid rule requested.');
+    }
+
+    if (!empty($with)) {
+      foreach ($with as $key => $value) {
+        $rules[$rule]->set($key, $value);
+      }
+    }
+
+    return $rules[$rule];
+  }
+
   /**
    * Determine if a given path is valid.
    *
    * {@inheritdoc}
    */
   public function assert() {
+    $paths = [];
+    $matcher = \Drupal::service('path.matcher');
 
-    // @TODO do we want to use a strtolower here? e.g. $pages = Unicode::strtolower($this->configuration['pages']);
+    foreach ($this->get('paths') as $key => $value) {
+      $path = is_numeric($key) ? $value : $key;
+      $opts = is_numeric($key) ? [] : $value;
 
-    // We have to convert the array into a set of patterns separated by a newline.
-    $paths = implode("\n", $this->get('paths'));
-    return \Drupal::service('path.matcher')->matchPath($this->get('current_path'), $paths);
+      $matched = $matcher->matchPath($this->get('current_path'), $path);
+
+      if (!$matched) {
+        // Move the the next path if this path was not matched.
+        continue;
+      }
+
+      if ($matched && isset($opts['auth'])) {
+        $auth_rule = $this->getRule('auth', [
+          'request' => \Drupal::request(),
+          'credentials' => $opts['auth'],
+        ]);
+
+        return $auth_rule->assert();
+      }
+
+      // Path was found and has no addtional rules.
+      return TRUE;
+    }
+
+    // Current path does not match a rule in settings.
+    return FALSE;
   }
 
 }

--- a/src/Rules/PathRule.php
+++ b/src/Rules/PathRule.php
@@ -28,6 +28,14 @@ class PathRule extends RulesInterface {
     return $rules[$rule];
   }
 
+  public function getMatcher() {
+    return \Drupal::service('path.matcher');
+  }
+
+  public function getRequest() {
+    return \Drupal::request();
+  }
+
   /**
    * Determine if a given path is valid.
    *
@@ -35,7 +43,7 @@ class PathRule extends RulesInterface {
    */
   public function assert() {
     $paths = [];
-    $matcher = \Drupal::service('path.matcher');
+    $matcher = $this->getMatcher();
 
     foreach ($this->get('paths') as $key => $value) {
       $path = is_numeric($key) ? $value : $key;
@@ -50,7 +58,7 @@ class PathRule extends RulesInterface {
 
       if ($matched && isset($opts['auth'])) {
         $auth_rule = $this->getRule('auth', [
-          'request' => \Drupal::request(),
+          'request' => $this->getRequest(),
           'credentials' => $opts['auth'],
         ]);
 

--- a/src/Rules/RulesInterface.php
+++ b/src/Rules/RulesInterface.php
@@ -11,8 +11,13 @@ abstract class RulesInterface {
 
   /**
    * Magic setter.
-   * @param [type] $key   [description]
-   * @param [type] $value [description]
+   *
+   * @param string $key
+   *   Property for the rule.
+   * @param mixed $value
+   *   Value for the $key.
+   *
+   * @return \Drupal\restrict\Rules\RulesInterface
    */
   public function set($key, $value) {
     $this->{strtolower($key)} = $value;
@@ -21,8 +26,11 @@ abstract class RulesInterface {
 
   /**
    * Magic getter.
-   * @param  [type] $key [description]
-   * @return [type]      [description]
+   *
+   * @param string $key
+   *   The property to access.
+   *
+   * @return mixed|array
    */
   public function get($key) {
     return isset($this->{strtolower($key)}) ? $this->{strtolower($key)} : [];

--- a/tests/src/Unit/BasicAuthRuleTest.php
+++ b/tests/src/Unit/BasicAuthRuleTest.php
@@ -86,7 +86,7 @@ class BasicAuthRuleTest extends UnitTestCase {
       ->with('credentials')
       ->willReturn([]);
 
-    $this->assertTure($this->rule->assert());
+    $this->assertTrue($this->rule->assert());
   }
 
   /**

--- a/tests/src/Unit/BasicAuthRuleTest.php
+++ b/tests/src/Unit/BasicAuthRuleTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\Tests\restrict\Unit\BasicAuthRuleTest
+ */
+
+namespace Drupal\Tests\restrict\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\restrict\Rules\BasicAuthRule;
+
+/**
+ * Class BasicAuthRuleTest
+ *
+ * @coversDefaultClass \Drupal\restrict\Rules\BasicAuthRule
+ * @group restrict
+ */
+class BasicAuthRuleTest extends UnitTestCase {
+
+  use RequestMockTrait;
+
+  /**
+   * The BasicAuthRule instance.
+   *
+   * @var Drupal\restrict\Rules\BasicAuthRule
+   */
+  protected $rule;
+
+
+  /**
+   * A instance of Request.
+   *
+   * @var Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * A test username.
+   *
+   * @var string
+   */
+  protected $username = 'username';
+
+  /**
+   * A test password.
+   *
+   * @var string
+   */
+  protected $password = 'password';
+
+  /**
+   * Build a mocked rule for testing.
+   */
+  public function setup() {
+    $this->rule = $this->getMockBuilder('Drupal\restrict\Rules\BasicAuthRule')
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMock();
+
+    // Set up the request mock.
+    $this->request = $this->getRequestMock();
+
+    $this->request->headers->expects($this->any())
+      ->method('get')
+      ->with('PHP_AUTH_USER')
+      ->willReturn($this->username);
+
+    $this->request->headers->expects($this->any())
+      ->method('get')
+      ->with('PHP_AUTH_PW')
+      ->willRequtr($this->password);
+
+    // When asked the rule will access the mocked request.
+    $this->rule->expects($this->any())
+      ->method('get')
+      ->with('request')
+      ->willReturn($this->request);
+  }
+
+  /**
+   * Ensure that if the rule has no credentials it always passes.
+   */
+  public function testNoCredentials() {
+    $this->rule->expects($this->once())
+      ->method('get')
+      ->with('credentials')
+      ->willReturn([]);
+
+    $this->assertTure($this->rule->assert());
+  }
+
+  /**
+   * Ensure that valid credentials results in a valid rule.
+   */
+  public function testValidCredentials() {
+    $this->rule->expects($this->once())
+      ->method('get')
+      ->with('credentials')
+      ->willreutrn([$this->username => $this->password]);
+
+    $this->assertTrue($this->rule->assert());
+  }
+
+  /**
+   * Ensure that invalid credentials are blocked.
+   */
+  public function testInvalidCredentials() {
+    $this->rule->expects($this->once())
+      ->method('get')
+      ->with('credentials')
+      ->willReturn(['fake' => 'p455w0rd']);
+
+    $this->assertFalse($this->rule->assert());
+  }
+}

--- a/tests/src/Unit/BasicAuthRuleTest.php
+++ b/tests/src/Unit/BasicAuthRuleTest.php
@@ -68,7 +68,7 @@ class BasicAuthRuleTest extends UnitTestCase {
     $this->request->headers->expects($this->any())
       ->method('get')
       ->with('PHP_AUTH_PW')
-      ->willRequtr($this->password);
+      ->willReturn($this->password);
 
     // When asked the rule will access the mocked request.
     $this->rule->expects($this->any())

--- a/tests/src/Unit/BasicAuthRuleTest.php
+++ b/tests/src/Unit/BasicAuthRuleTest.php
@@ -62,29 +62,21 @@ class BasicAuthRuleTest extends UnitTestCase {
 
     $this->request->headers->expects($this->any())
       ->method('get')
-      ->with('PHP_AUTH_USER')
-      ->willReturn($this->username);
-
-    $this->request->headers->expects($this->any())
-      ->method('get')
-      ->with('PHP_AUTH_PW')
-      ->willReturn($this->password);
-
-    // When asked the rule will access the mocked request.
-    $this->rule->expects($this->any())
-      ->method('get')
-      ->with('request')
-      ->willReturn($this->request);
+      ->withConsecutive(
+        ['PHP_AUTH_USER', NULL, FALSE],
+        ['PHP_AUTH_PW', NULL, FALSE]
+      )
+      ->willReturnOnConsecutiveCalls($this->username, $this->password);
   }
 
   /**
    * Ensure that if the rule has no credentials it always passes.
    */
   public function testNoCredentials() {
-    $this->rule->expects($this->once())
+    $this->rule->expects($this->exactly(1))
       ->method('get')
-      ->with('credentials')
-      ->willReturn([]);
+      ->withConsecutive(['credentials'])
+      ->willReturnOnConsecutiveCalls([]);
 
     $this->assertTrue($this->rule->assert());
   }
@@ -93,10 +85,10 @@ class BasicAuthRuleTest extends UnitTestCase {
    * Ensure that valid credentials results in a valid rule.
    */
   public function testValidCredentials() {
-    $this->rule->expects($this->once())
+      $this->rule->expects($this->exactly(3))
       ->method('get')
-      ->with('credentials')
-      ->willreutrn([$this->username => $this->password]);
+      ->withConsecutive(['credentials'], ['request'], ['request'])
+      ->willReturnOnConsecutiveCalls([$this->username => $this->password], $this->request, $this->request);
 
     $this->assertTrue($this->rule->assert());
   }
@@ -105,10 +97,10 @@ class BasicAuthRuleTest extends UnitTestCase {
    * Ensure that invalid credentials are blocked.
    */
   public function testInvalidCredentials() {
-    $this->rule->expects($this->once())
+    $this->rule->expects($this->exactly(3))
       ->method('get')
-      ->with('credentials')
-      ->willReturn(['fake' => 'p455w0rd']);
+      ->withConsecutive(['credentials'], ['request'], ['request'])
+      ->willReturnOnConsecutiveCalls(['fake' => 'p455w0rd'], $this->request, $this->request);
 
     $this->assertFalse($this->rule->assert());
   }

--- a/tests/src/Unit/PathRuleTest.php
+++ b/tests/src/Unit/PathRuleTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\Tests\restrict\Unit\PathRuleTest
+ */
+
+namespace Drupal\Tests\restrict\Unit;
+
+use Drupal\restrict\Rules\PathRule;
+use Drupal\restrict\Rules\BasicAuthRule;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for path checking with options.
+ *
+ * @coversDefaultClass \Drupal\restrict\Rules\PathRule
+ * @group restrict
+ */
+class PathRuleTest extends UnitTestCase {
+
+  /**
+   * The current path.
+   *
+   * @var string
+   */
+  protected $current_path = '/path';
+
+  /**
+   * The PathRule instance.
+   *
+   * @var Drupal\restrict\Rules\PathRule
+   */
+  protected $rule;
+
+  /**
+   * The BasicAuthRule instance.
+   *
+   * @var Drupal\restrict\Rules\BasicAuthRule
+   */
+  protected $authRule;
+
+  /**
+   * Build the required mocks for testing.
+   */
+  public function setup() {
+    $this->rule = $this->getMockBuilder('Drupal\restrict\Rules\PathRule')
+      ->disableOriginalConstructor()
+      ->setMethods(['getRule'])
+      ->getMock();
+
+    $this->rule->set('current_path', $this->current_path);
+
+    // Set up a mock BasicAuthRule.
+    $this->authRule = $this->getMockBuilder('Drupal\restrict\Rules\BasicAuthRule')
+      ->disableOriginalConstructor()
+      ->setMethods(['set', 'assert'])
+      ->getMock();
+  }
+
+  /**
+   * Ensure paths are matched correctly.
+   */
+  public function testPathIsRestricted() {
+    $paths = [$this->current_path];
+    $this->rule->set('paths', $paths);
+
+    $this->rule->expects($this->never())->method('getRule');
+
+    $this->assertTrue($this->rule->assert());
+  }
+
+  /**
+   * Ensure paths can be matched in the array.
+   */
+  public function testPathInRestricted() {
+    $paths = [
+      '/test',
+      '/test2',
+      $this->current_path,
+      '/test3',
+    ];
+    $this->rule->set('paths', $paths);
+
+    $this->rule->expects($this->never())->method('getRule');
+
+    $this->assertTrue($this->rule->assert());
+  }
+
+  /**
+   * Ensure that a path restriction with correct login information will return true.
+   */
+  public function testPathAuthAccepted() {
+    $paths = [
+      $this->current_path => [
+        'auth' => ['username' => 'password'],
+      ],
+    ];
+
+    $authRule = $this->authRule;
+
+    $authRule->expects($this->once())
+      ->method('set')
+      ->with('credentials', ['username' => 'password']);
+
+    $authRule->expects($this->once())
+      ->method('assert')
+      ->willReturn(TRUE);
+
+    $this->rule->expects($this->once())
+      ->method('getRule')
+      ->willReturn($this->authRule);
+
+    $this->assertTrue($this->rule->assert());
+  }
+
+  /**
+   * Ensure that a path restriction with incorrect login informaiton will return false.
+   */
+  public function testPathAuthRestricted() {
+    $paths = [
+      $this->current_path => [
+        'auth' => ['username' => 'password'],
+      ],
+    ];
+
+    $authRule = $this->authRule;
+
+    $authRule->expects($this->once())
+      ->method('set')
+      ->with('credentials', ['username' => 'password']);
+
+    $authRule->expects($this->once())
+      ->method('assert')
+      ->willReturn(FALSE);
+
+    $this->rule->expects($this->once())
+      ->method('getRule')
+      ->willReturn($this->authRule);
+
+    $this->assertFalse($this->rule->assert());
+  }
+
+}

--- a/tests/src/Unit/RequestMockTrait.php
+++ b/tests/src/Unit/RequestMockTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\Tests\restrict\Unit\RequestMockTrait
+ */
+
+namespace Drupal\Tests\restrict\Unit;
+
+
+trait RequestMockTrait {
+
+  /**
+   * Generate a Request Mock object.
+   *
+   * @return Symfony\Component\HttpFoundation\Request
+   */
+  public function getRequestMock() {
+    $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Setup a mock for $request->request parameter bag.
+    $params = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+      ->disableOriginalConstructor()
+      ->setMethods(['getClientIp', 'getRequestUri'])
+      ->getMock();
+
+    // Setup a mock for $request->server parameter bag.
+    $server = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMock();
+
+    $server->expects($this->any())
+      ->method('get')
+      ->with('REMOTE_ADDR')
+      ->willReturn('127.0.0.1');
+
+    // Setup a mock for $request->headers parameter bag.
+    $headers = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMock();
+
+    $headers->expects($this->any())
+      ->method('get')
+      ->willReturn('user');
+
+    $request->server = $server;
+    $request->request = $params;
+    $request->headers = $headers;
+
+    return $request;
+  }
+
+}

--- a/tests/src/Unit/RequestMockTrait.php
+++ b/tests/src/Unit/RequestMockTrait.php
@@ -42,10 +42,6 @@ trait RequestMockTrait {
       ->setMethods(['get'])
       ->getMock();
 
-    $headers->expects($this->any())
-      ->method('get')
-      ->willReturn('user');
-
     $request->server = $server;
     $request->request = $params;
     $request->headers = $headers;

--- a/tests/src/Unit/RestrictManagerTest.php
+++ b/tests/src/Unit/RestrictManagerTest.php
@@ -17,49 +17,7 @@ use Drupal\restrict\RestrictManager;
  */
 class RestrictManagerTest extends UnitTestCase {
 
-  /**
-   * Generate a Request Mock object.
-   *
-   * @return Symfony\Component\HttpFoundation\Request
-   */
-  public function getRequestMock() {
-    $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
-      ->disableOriginalConstructor()
-      ->getMock();
-
-    // Setup a mock for $request->request parameter bag.
-    $params = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
-      ->disableOriginalConstructor()
-      ->setMethods(['getClientIp', 'getRequestUri'])
-      ->getMock();
-
-    // Setup a mock for $request->server parameter bag.
-    $server = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
-      ->disableOriginalConstructor()
-      ->setMethods(['get'])
-      ->getMock();
-
-    $server->expects($this->any())
-      ->method('get')
-      ->with('REMOTE_ADDR')
-      ->willReturn('127.0.0.1');
-
-    // Setup a mock for $request->headers parameter bag.
-    $headers = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
-      ->disableOriginalConstructor()
-      ->setMethods(['get'])
-      ->getMock();
-
-    $headers->expects($this->any())
-      ->method('get')
-      ->willReturn('user');
-
-    $request->server = $server;
-    $request->request = $params;
-    $request->headers = $headers;
-
-    return $request;
-  }
+  use RequestMockTrait;
 
   /**
    * Return a mock manager.


### PR DESCRIPTION
Updates the path rule so that it can accept configuration for each path. This branch only allows the auth restriction to paths.
- Added BasicAuthRule to handle accepting user credentials
- Updates README.md to document new settings
- Remains backwards compatible with old settings
- Updates PathRule to check for credentials

Fixes #7 
